### PR TITLE
Beanfactory issue

### DIFF
--- a/+mdepin/BeanFactory.m
+++ b/+mdepin/BeanFactory.m
@@ -39,7 +39,8 @@ classdef BeanFactory < handle
                 end
                 config = mdepin.StructConfig( params );
                 obj.Beans(beanId) = ctor( config );
-            end                                    
+            end
+            obj.IsInitialized = true;
         end
         
         function bean = getBean(obj, beanId)

--- a/+mdepin/getBeanFactory.m
+++ b/+mdepin/getBeanFactory.m
@@ -1,0 +1,19 @@
+function factory  = getBeanFactory(file)
+
+run(which(file));
+variables = who;
+
+if numel(variables) > 2
+    error('only one structure is allowed in context file')
+end
+
+ctx = eval(variables{1});
+
+if isstruct( ctx )
+    ctx = mdepin.StructContext(ctx);
+end
+% Construct the application
+factory = mdepin.BeanFactory(ctx);
+end
+
+


### PR DESCRIPTION
Hi,
This pull request contains,
- Fix for issue#1 BeanFactory.getBean always returns new instance
- Constructs bean factory from external script.m (below) which defines context structure and return it   to user
  
  ``` matlab
  # File script.m
  
  ctx = struct();
  ctx.analysisDao.class = 'symphony.analysis.dao.AnalysisDao';
  ctx.analysisDao.repository = 'fileRepository';
  
  ctx.preferenceDao.class = 'symphony.analysis.dao.PreferenceDao';
  ctx.preferenceDao.repository = 'fileRepository';
  ctx.fileRepository.class = 'symphony.analysis.app.FileRepository';
  ```
